### PR TITLE
Lib: json.py : correction du début de trame sous scapy

### DIFF
--- a/lib/json.py
+++ b/lib/json.py
@@ -44,7 +44,7 @@ def verif_and_construction_json(queue_beacon_sie):
         vs_type = (trame[scapy.Dot11EltVendorSpecific].info[3:4])     # vs_type de la trame
         
         dataDict = {}
-        data = trame[scapy.Dot11EltVendorSpecific].info[1:]
+        data = trame[scapy.Dot11EltVendorSpecific].info[4:]  # start after OUI+VS_TYPE
         
         try:
             if vs_type == vs_protocole and len(str(trame[scapy.Dot11EltVendorSpecific].info)) > 30: # taille minimale de la trame


### PR DESCRIPTION
Sous Ubuntu 20.04, avec scapy 2.4.3, le debut de la trame est au bits numéro 3 de la table info. Les 3 premiers correspondent au numéro OUI.
Le code actuel ne permet donc pas de décoder correctement les trames.
La modification suivante corrige le problème.